### PR TITLE
Support for checking cross-origin headers

### DIFF
--- a/secheaders/constants.py
+++ b/secheaders/constants.py
@@ -3,7 +3,7 @@ DEFAULT_URL_SCHEME = 'https'
 DEFAULT_TIMEOUT = 10
 
 # Let's try to imitate a legit browser to avoid being blocked / flagged as web crawler
-REQUEST_HEADERS = {
+DEFAULT_GET_HEADERS = {
     'Accept': ('text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,'
                'application/signed-exchange;v=b3;q=0.9'),
     'Accept-Encoding': 'gzip, deflate, br',
@@ -12,6 +12,14 @@ REQUEST_HEADERS = {
     'User-Agent': ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)'
                    'Chrome/106.0.0.0 Safari/537.36'),
 }
+
+PREFLIGHT_HEADERS = {
+    **DEFAULT_GET_HEADERS,
+    'Access-Control-Request-Method': 'GET',
+    'Origin': 'https://nonexistent.example.com',
+    'Cookie': 'SESSIONID=123',
+}
+
 
 EVAL_WARN = 0
 EVAL_OK = 1

--- a/secheaders/secheaders.py
+++ b/secheaders/secheaders.py
@@ -71,14 +71,13 @@ def scan_target(url, args):
         https = web_client.test_https()
         target = web_client.get_full_url()
         cors_headers = web_client.get_headers(method='OPTIONS', headers=PREFLIGHT_HEADERS)
-        print(str(cors_headers), file=sys.stderr)
     elif args.file:
         headers = parse_file_input(args.file)
         target = args.file
     else:
         raise SecurityHeadersException("Failed to fetch headers, no sufficient input provided.")
 
-    analysis_result = analyze_headers(headers)
+    analysis_result = analyze_headers(headers, cors_headers)
     return {'target': target, 'headers': analysis_result, 'https': https}
 
 

--- a/secheaders/secheaders.py
+++ b/secheaders/secheaders.py
@@ -3,6 +3,8 @@ import asyncio
 import json
 import sys
 
+from secheaders.constants import PREFLIGHT_HEADERS
+
 
 from . import cmd_utils
 from .exceptions import SecurityHeadersException, FailedToFetchHeaders
@@ -60,13 +62,16 @@ def async_scan_done(scan):
 def scan_target(url, args):
     https = None
     target = None
+    cors_headers = None
     if url:
         web_client = WebClient(url, args.max_redirects, args.insecure)
         headers = web_client.get_headers()
-        https = web_client.test_https()
-        target = web_client.get_full_url()
         if not headers:
             raise FailedToFetchHeaders("Failed to fetch headers")
+        https = web_client.test_https()
+        target = web_client.get_full_url()
+        cors_headers = web_client.get_headers(method='OPTIONS', headers=PREFLIGHT_HEADERS)
+        print(str(cors_headers), file=sys.stderr)
     elif args.file:
         headers = parse_file_input(args.file)
         target = args.file

--- a/secheaders/webclient.py
+++ b/secheaders/webclient.py
@@ -5,7 +5,7 @@ import ssl
 from typing import Union
 from urllib.parse import ParseResult, urlparse
 
-from .constants import DEFAULT_TIMEOUT, DEFAULT_URL_SCHEME, REQUEST_HEADERS, HEADER_STRUCTURED_LIST
+from .constants import DEFAULT_TIMEOUT, DEFAULT_URL_SCHEME, HEADER_STRUCTURED_LIST, DEFAULT_GET_HEADERS
 from .exceptions import InvalidTargetURL, UnableToConnect
 
 
@@ -53,7 +53,7 @@ class WebClient():
                 raise InvalidTargetURL("Unsupported protocol scheme")
 
             try:
-                conn.request('GET', temp_url.path, headers=REQUEST_HEADERS)
+                conn.request('GET', temp_url.path, headers=DEFAULT_GET_HEADERS)
                 res = conn.getresponse()
             except (socket.gaierror, socket.timeout, ConnectionRefusedError, UnicodeError) as e:
                 raise UnableToConnect(f"Connection failed {temp_url.netloc}") from e
@@ -98,13 +98,15 @@ class WebClient():
 
         return conn
 
-    def get_headers(self) -> dict:
+    def get_headers(self, method='GET', headers=None) -> dict:
         """ Fetch headers from the target site """
         retval = {}
+        if not headers:
+            headers = DEFAULT_GET_HEADERS
 
         conn = self.open_connection(self.target_url)
         try:
-            conn.request('GET', self.target_url.path, headers=REQUEST_HEADERS)
+            conn.request(method=method, url=self.target_url.path, headers=headers)
             res = conn.getresponse()
         except (socket.gaierror, socket.timeout, ConnectionRefusedError, ssl.SSLError, UnicodeError) as e:
             raise UnableToConnect(f"Connection failed {self.target_url.hostname}") from e


### PR DESCRIPTION
Support for checking cross-origin headers
```
cross-origin-allow-origin
cross-origin-resource-policy
cross-origin-opener-policy
cross-origin-embedder-policy
cross-origin-allow-credentials
cross-origin-allow-methods
```

